### PR TITLE
Skipping more licenseless categories (fix #2)

### DIFF
--- a/vrms-gentoo
+++ b/vrms-gentoo
@@ -16,6 +16,7 @@ use warnings;
 
 $| = 1;
 
+use List::Util qw(any);
 use Term::ANSIColor;
 use Getopt::Long;
 
@@ -146,8 +147,11 @@ close LGF;
 opendir(D, "/var/db/pkg") || die('No package directory found. Are you on Gentoo?');
 
 while(my $category = readdir(D)) {
-    # Virtual packages don't have license.
-    next if ($category eq '.' || $category eq '..' || $category eq 'virtual' );
+    # Skip categories that don't have a license
+    next if any {$_ eq $category} (
+        ".", "..",
+        "virtual", "acct-user", "acct-group"
+    );
 
     opendir(C, "/var/db/pkg/$category");
     while(my $package = readdir(C)) {


### PR DESCRIPTION
The special packages in categories "acct-user" and "acct-group" should be ignored because they do not have a license attached to them.

I'm not used to contributing Perl code, please let me know if there's anything wrong with my patch.