### PR TITLE
Check the right license_groups location from path in PORTDIR.

### DIFF
--- a/vrms-gentoo
+++ b/vrms-gentoo
@@ -33,6 +33,14 @@ my $total = 0;
 my $hostname = "";
 chop( $hostname = `uname -n`);
 
+my $license_groups_location = "";
+chop( $license_groups_location = `portageq get_repo_path / gentoo`);
+if ( $? == -1 )
+{ 
+    die('Portageq not found. Are you on Gentoo?');
+}
+$license_groups_location = "$license_groups_location/profiles/license_groups";
+
 # Options
 my $help = 0;
 my $quiet = 0;
@@ -128,7 +136,7 @@ printf "Scanning packages...";
 
 # Parse portage's license_groups file to see which licenses
 # are considered free
-open LGF, '<', "/usr/portage/profiles/license_groups" || die('No license groups found. Are you on Gentoo?');
+open LGF, '<', $license_groups_location || die('No license groups found. Are you on Gentoo?');
 while( my $line = <LGF> ) {
     next unless $line =~ /\S/;
     next if $line =~ /^#/;


### PR DESCRIPTION
[The default location for repositories has changed](https://wiki.gentoo.org/wiki//var/db/repos/gentoo), so on newer gentoo installs this script will not find license_groups and therefore wont be able to differentiate between free and non-free licenses. The commit should fix this by checking first that either `/usr/portage/profiles/license_groups` or `/var/d/repos/gentoo/profiles/license_groups` exists and then opens the one it finds.